### PR TITLE
Added model for Groups

### DIFF
--- a/src/Opifex.Scim2.Core/Group.cs
+++ b/src/Opifex.Scim2.Core/Group.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+
+namespace Opifex.Scim2.Core
+{
+    public class Group<TKey, T2Key> : Resource<TKey>
+        where TKey : IKey
+        where T2Key : IKey
+    {
+        public string DisplayName { get; }
+
+        public List<User<T2Key>> Members { get; }
+    }
+}


### PR DESCRIPTION
Added the `Group` class that represents groups as part of the SCIM 2.0 core schema. See [RFC 7643 Section 4.2](https://tools.ietf.org/html/rfc7643#section-4.2) for more details.